### PR TITLE
Fix: Remove keyframes if animation declaration is not used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -316,7 +316,23 @@ const getPrettyStylesFromClassNames = (classNames, elements) => {
   // ensure document level root custom properties are removed
   parsedStyles.stylesheet.rules = parsedStyles.stylesheet.rules
     .map((rule) => {
-      if (rule.selectors?.includes(':root')) return null
+      if (rule.type === 'keyframes') {
+        let tempRule = null
+        parsedStyles.stylesheet.rules.some((otherRule) =>
+          otherRule.declarations?.some((declaration) => {
+            if (
+              declaration.property === 'animation-name' ||
+              declaration.property === 'animation'
+            ) {
+              if (declaration.value === rule.name) tempRule = rule
+            }
+          })
+        )
+        return tempRule
+      }
+      if (rule.selectors?.includes(':root')) {
+        return null
+      }
       return rule
     })
     .filter(Boolean)

--- a/src/index.js
+++ b/src/index.js
@@ -321,10 +321,11 @@ const getPrettyStylesFromClassNames = (classNames, elements) => {
         parsedStyles.stylesheet.rules.some((otherRule) =>
           otherRule.declarations?.some((declaration) => {
             if (
-              declaration.property === 'animation-name' ||
-              declaration.property === 'animation'
+              (declaration.property === 'animation-name' ||
+                declaration.property === 'animation') &&
+              declaration.value === rule.name
             ) {
-              if (declaration.value === rule.name) tempRule = rule
+              tempRule = rule
             }
           })
         )


### PR DESCRIPTION
If the CSS rule is `@keyframes`, loop through other selectors in the snapshot, loop those each CSS declaration within those selectors and check that animation is used. If it is, include within snapshot, otherwise exclude. As an example

```jsx
it('includes the keyframes property in the snapshot', async () => {
  // isLoading uses a keyframe animation
  const { container } = render(
    <Button isLoading>Hello</Button>
  )
  expect(container).toMatchSnapshot()
})

it('excludes the keyframes property in the snapshot', async () => {
  // if there is no HTML using the keyframe animation, it won't be rendered
  const { container } = render(
    <Button>Hello</Button>
  )
  expect(container).toMatchSnapshot()
})
```
